### PR TITLE
Aplicación del principio SRP en servicios y consultas LINQ

### DIFF
--- a/BusinessRules/ClientOrderMapper.cs
+++ b/BusinessRules/ClientOrderMapper.cs
@@ -1,0 +1,20 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+
+namespace Lab08_SantiagoPisconteChuctaya.BusinessRules;
+
+public class ClientOrderMapper
+{
+    public static ClientsOrderDto Map(Client client)
+    {
+        return new ClientsOrderDto
+        {
+            ClientName = client.Name,
+            Orders = client.Orders.Select(o => new OrdersDto
+            {
+                OrderId = o.OrderId,
+                OrderDate = o.OrderDate
+            }).ToList()
+        };
+    }
+}

--- a/BusinessRules/ClientSalesCalculator.cs
+++ b/BusinessRules/ClientSalesCalculator.cs
@@ -1,0 +1,12 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+
+namespace Lab08_SantiagoPisconteChuctaya.BusinessRules;
+
+public class ClientSalesCalculator
+{
+    public static decimal CalcularTotalVentas(List<Order> orders)
+    {
+        return orders.Sum(order => order.Orderdetails
+            .Sum(detail => detail.Quantity * detail.Product.Price));
+    }
+}

--- a/BusinessRules/OrderDetailsMapper.cs
+++ b/BusinessRules/OrderDetailsMapper.cs
@@ -1,0 +1,22 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+
+namespace Lab08_SantiagoPisconteChuctaya.BusinessRules;
+
+public class OrderDetailsMapper
+{
+    public static OrderDetailsDto Map(Order order)
+    {
+        return new OrderDetailsDto
+        {
+            OrderId = order.OrderId,
+            OrderDate = order.OrderDate,
+            Products = order.Orderdetails.Select(od => new ProductsDto
+            {
+                ProductName = od.Product.Name,
+                Quantity = od.Quantity,
+                Price = od.Product.Price
+            }).ToList()
+        };
+    }
+}

--- a/Controllers/Lab09Controller.cs
+++ b/Controllers/Lab09Controller.cs
@@ -1,0 +1,45 @@
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+using Lab08_SantiagoPisconteChuctaya.Persistence.Implementations;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Lab08_SantiagoPisconteChuctaya.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class Lab09Controller : ControllerBase
+{
+    private readonly ILab09Service _lab09Service;
+
+    public Lab09Controller(ILab09Service lab09Service)
+    {
+        _lab09Service = lab09Service;
+    }
+    
+    [HttpGet("orders")]
+    public async Task<ActionResult<List<ClientsOrderDto>>> GetAllOrders()
+    {
+        var result = await _lab09Service.GetAllOrders();
+        return Ok(result);
+    }
+
+    [HttpGet("order-details")]
+    public async Task<ActionResult<List<OrderDetailsDto>>> GetInclude()
+    {
+        var result = await _lab09Service.GetInclude();
+        return Ok(result);
+    }
+
+    [HttpGet("client-products-summary")]
+    public async Task<ActionResult<List<string>>> GetConsultationDouble()
+    {
+        var result = await _lab09Service.GetConsultationDouble();
+        return Ok(result);
+    }
+
+    [HttpGet("sales-by-client")]
+    public async Task<ActionResult<List<SalesByClientDto>>> GetAgroup()
+    {
+        var result = await _lab09Service.GetAgroup();
+        return Ok(result);
+    }
+}

--- a/Dtos/ClientsOrderDto.cs
+++ b/Dtos/ClientsOrderDto.cs
@@ -1,0 +1,7 @@
+namespace Lab08_SantiagoPisconteChuctaya.Dtos;
+
+public class ClientsOrderDto
+{
+    public string ClientName { get; set; }
+    public List<OrdersDto> Orders { get; set; }
+}

--- a/Dtos/OrderDetailsDto.cs
+++ b/Dtos/OrderDetailsDto.cs
@@ -1,0 +1,8 @@
+namespace Lab08_SantiagoPisconteChuctaya.Dtos;
+
+public class OrderDetailsDto
+{
+    public int OrderId { get; set; }
+    public DateTime OrderDate { get; set; }
+    public List<ProductsDto> Products { get; set; }
+}

--- a/Dtos/OrdersDto.cs
+++ b/Dtos/OrdersDto.cs
@@ -1,0 +1,7 @@
+namespace Lab08_SantiagoPisconteChuctaya.Dtos;
+
+public class OrdersDto
+{
+    public int OrderId { get; set; }
+    public DateTime OrderDate { get; set; }
+}

--- a/Dtos/ProductsDto.cs
+++ b/Dtos/ProductsDto.cs
@@ -1,0 +1,8 @@
+namespace Lab08_SantiagoPisconteChuctaya.Dtos;
+
+public class ProductsDto
+{
+    public string ProductName { get; set; }
+    public int Quantity { get; set; }
+    public decimal Price { get; set; }
+}

--- a/Dtos/SalesByClientDto.cs
+++ b/Dtos/SalesByClientDto.cs
@@ -1,0 +1,7 @@
+namespace Lab08_SantiagoPisconteChuctaya.Dtos;
+
+public class SalesByClientDto
+{
+    public string ClientName { get; set; }
+    public decimal TotalSales { get; set; }
+}

--- a/Persistence/Queries/ClientsOrdersQuery.cs
+++ b/Persistence/Queries/ClientsOrdersQuery.cs
@@ -1,0 +1,33 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
+
+public class ClientsOrdersQuery
+{
+    private readonly LINQPisconteContext _context;
+
+    public ClientsOrdersQuery(LINQPisconteContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<ClientsOrderDto>> GetAllOrdersAsync()
+    {
+        var clients = await _context.Clients
+            .Include(c => c.Orders)
+            .AsNoTracking()
+            .ToListAsync();
+
+        return clients.Select(c => new ClientsOrderDto
+        {
+            ClientName = c.Name,
+            Orders = c.Orders.Select(o => new OrdersDto
+            {
+                OrderId = o.OrderId,
+                OrderDate = o.OrderDate
+            }).ToList()
+        }).ToList();
+    }
+}

--- a/Persistence/Queries/ClientsProductsSummaryQuery.cs
+++ b/Persistence/Queries/ClientsProductsSummaryQuery.cs
@@ -1,0 +1,30 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
+
+public class ClientsProductsSummaryQuery
+{
+    private readonly LINQPisconteContext _context;
+
+    public ClientsProductsSummaryQuery(LINQPisconteContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<string>> GetClientsProductsSummaryAsync()
+    {
+        var result = await _context.Clients
+            .AsNoTracking()
+            .Select(client => new
+            {
+                ClientName = client.Name,
+                TotalProducts = client.Orders
+                    .Sum(order => order.Orderdetails
+                        .Sum(detail => detail.Quantity))
+            })
+            .ToListAsync();
+
+        return result.Select(x => $"{x.ClientName} compró {x.TotalProducts} productos").ToList();
+    }
+}

--- a/Persistence/Queries/OrdersDetailsQuery.cs
+++ b/Persistence/Queries/OrdersDetailsQuery.cs
@@ -1,0 +1,36 @@
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
+
+public class OrdersDetailsQuery
+{
+    private readonly LINQPisconteContext _context;
+
+    public OrdersDetailsQuery(LINQPisconteContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<OrderDetailsDto>> GetOrdersWithDetailsAsync()
+    {
+        var orders = await _context.Orders
+            .Include(o => o.Orderdetails)
+            .ThenInclude(od => od.Product)
+            .AsNoTracking()
+            .ToListAsync();
+
+        return orders.Select(order => new OrderDetailsDto
+        {
+            OrderId = order.OrderId,
+            OrderDate = order.OrderDate,
+            Products = order.Orderdetails.Select(od => new ProductsDto
+            {
+                ProductName = od.Product.Name,
+                Quantity = od.Quantity,
+                Price = od.Product.Price
+            }).ToList()
+        }).ToList();
+    }
+}

--- a/Persistence/Queries/SalesByClientQuery.cs
+++ b/Persistence/Queries/SalesByClientQuery.cs
@@ -1,0 +1,36 @@
+using Lab08_SantiagoPisconteChuctaya.BusinessRules;
+using Lab08_SantiagoPisconteChuctaya.Data;
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+using Microsoft.EntityFrameworkCore;
+
+namespace Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
+
+public class SalesByClientQuery
+{
+    private readonly LINQPisconteContext _context;
+
+    public SalesByClientQuery(LINQPisconteContext context)
+    {
+        _context = context;
+    }
+
+    public async Task<List<SalesByClientDto>> GetSalesByClientAsync()
+    {
+        var clients = await _context.Clients
+            .Include(c => c.Orders)
+            .ThenInclude(o => o.Orderdetails)
+            .ThenInclude(od => od.Product)
+            .AsNoTracking()
+            .ToListAsync();
+
+        var result = clients.Select(c => new SalesByClientDto
+            {
+                ClientName = c.Name,
+                TotalSales = ClientSalesCalculator.CalcularTotalVentas(c.Orders.ToList())
+            })
+            .OrderByDescending(x => x.TotalSales)
+            .ToList();
+
+        return result;
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -2,6 +2,7 @@ using System.Text.Json.Serialization;
 using Lab08_SantiagoPisconteChuctaya.Data;
 using Lab08_SantiagoPisconteChuctaya.Persistence;
 using Lab08_SantiagoPisconteChuctaya.Persistence.Implementations;
+using Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
 using Lab08_SantiagoPisconteChuctaya.Persistence.Repositories;
 using Lab08_SantiagoPisconteChuctaya.Services;
 using Microsoft.EntityFrameworkCore;
@@ -35,6 +36,13 @@ builder.Services.AddScoped<IClientService, ClientService>();
 builder.Services.AddScoped<IProductService, ProductService>();
 builder.Services.AddScoped<IOrderDetailService, OrderDetailService>();
 builder.Services.AddScoped<IOrderService, OrderService>();
+builder.Services.AddScoped<ILab09Service, Lab09Service>();
+
+builder.Services.AddScoped<ClientsOrdersQuery>();
+builder.Services.AddScoped<OrdersDetailsQuery>();
+builder.Services.AddScoped<ClientsProductsSummaryQuery>();
+builder.Services.AddScoped<SalesByClientQuery>();
+
 
 builder.Services.AddScoped<IUnitOfWork, UnitOfWork>();
 

--- a/Services/Implementations/ILab09Service.cs
+++ b/Services/Implementations/ILab09Service.cs
@@ -1,0 +1,11 @@
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+
+namespace Lab08_SantiagoPisconteChuctaya.Persistence.Implementations;
+
+public interface ILab09Service
+{
+    Task<List<ClientsOrderDto>> GetAllOrders();
+    Task<List<OrderDetailsDto>> GetInclude();
+    Task<List<string>> GetConsultationDouble();
+    Task<List<SalesByClientDto>> GetAgroup();
+}

--- a/Services/Lab09Service.cs
+++ b/Services/Lab09Service.cs
@@ -1,0 +1,46 @@
+using Lab08_SantiagoPisconteChuctaya.Dtos;
+using Lab08_SantiagoPisconteChuctaya.Persistence.Implementations;
+using Lab08_SantiagoPisconteChuctaya.Persistence.Queries;
+
+namespace Lab08_SantiagoPisconteChuctaya.Services;
+
+public class Lab09Service : ILab09Service
+{
+    private readonly ClientsOrdersQuery _clientsOrdersQuery;
+    private readonly OrdersDetailsQuery _ordersDetailsQuery;
+    private readonly ClientsProductsSummaryQuery _clientsProductsSummaryQuery;
+    private readonly SalesByClientQuery _salesByClientQuery;
+    
+    public Lab09Service(
+        ClientsOrdersQuery clientsOrdersQuery,
+        OrdersDetailsQuery ordersDetailsQuery,
+        ClientsProductsSummaryQuery clientsProductsSummaryQuery,
+        SalesByClientQuery salesByClientQuery)
+    {
+        _clientsOrdersQuery = clientsOrdersQuery;
+        _ordersDetailsQuery = ordersDetailsQuery;
+        _clientsProductsSummaryQuery = clientsProductsSummaryQuery;
+        _salesByClientQuery = salesByClientQuery;
+    }
+    
+    public async Task<List<ClientsOrderDto>> GetAllOrders()
+    {
+        return await _clientsOrdersQuery.GetAllOrdersAsync();
+
+    }
+    
+    public async Task<List<OrderDetailsDto>> GetInclude()
+    {
+        return await _ordersDetailsQuery.GetOrdersWithDetailsAsync();
+    } 
+    
+    public async Task<List<string>> GetConsultationDouble()
+    {
+        return await _clientsProductsSummaryQuery.GetClientsProductsSummaryAsync();
+    }
+
+    public async Task<List<SalesByClientDto>> GetAgroup()
+    {
+        return await _salesByClientQuery.GetSalesByClientAsync();
+    }
+}


### PR DESCRIPTION
Se realizó una refactorización del servicio Lab09Service aplicando el principio de responsabilidad única (SRP). Las consultas LINQ fueron extraídas y organizadas en clases independientes dentro de Persistence/Queries, mientras que la lógica de cálculo y mapeo fue trasladada a BusinessRules. Esta reestructuración mejora la legibilidad, mantenibilidad y escalabilidad del proyecto.